### PR TITLE
MarkdownConverter: Kotlin function type

### DIFF
--- a/src/main/kotlin/blog/HtmlController.kt
+++ b/src/main/kotlin/blog/HtmlController.kt
@@ -32,8 +32,8 @@ class HtmlController(private val repository: ArticleRepository,
 
 	fun Article.render() = RenderedArticle(
 			title,
-			markdownConverter.invoke(headline),
-			markdownConverter.invoke(content),
+			markdownConverter(headline),
+			markdownConverter(content),
 			author,
 			id,
 			addedAt.format()

--- a/src/main/kotlin/blog/HttpApi.kt
+++ b/src/main/kotlin/blog/HttpApi.kt
@@ -13,8 +13,8 @@ class ArticleController(private val repository: ArticleRepository,
 	@GetMapping("/{id}")
 	fun findOne(@PathVariable id: Long, @RequestParam converter: String?) = when (converter) {
 		"markdown" -> repository.findById(id).map { it.copy(
-				headline = markdownConverter.invoke(it.headline),
-				content = markdownConverter.invoke(it.content)) }
+				headline = markdownConverter(it.headline),
+				content = markdownConverter(it.content)) }
 		null -> repository.findById(id)
 		else -> throw IllegalArgumentException("Only markdown converter is supported")
 	}


### PR DESCRIPTION
If we are using Kotlin function type, it would be better to invoke `MarkdownConverter` as a function as well.