### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -711,7 +711,7 @@ class HtmlController(private val repository: ArticleRepository) {
 
 	@GetMapping("/")
 	fun blog(model: Model): String {
-		model["title"] = properties.title
+		model["title"] = "Blog"
 		model["articles"] = repository.findAllByOrderByAddedAtDesc().map { it.render() }
 		return "blog"
 	}


### PR DESCRIPTION
Obvious Fix. "properties.title" is not accessible on this step. It should be updated in the end of the guide when "private val properties: BlogProperties" is defined for HtmlController class.