### PR TITLE
Enable the all-open compiler plugin for @Embeddable and @MappedSuperclass too

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -545,6 +545,8 @@ apply plugin: 'kotlin-allopen'
 
 allOpen {
 	annotation("javax.persistence.Entity")
+	annotation('javax.persistence.Embeddable')
+	annotation('javax.persistence.MappedSuperclass')
 }
 ----
 
@@ -563,6 +565,8 @@ Or with Maven:
 		</compilerPlugins>
 		<pluginOptions>
 			<option>all-open:annotation=javax.persistence.Entity</option>
+			<option>all-open:annotation=javax.persistence.Embeddable</option>
+			<option>all-open:annotation=javax.persistence.MappedSuperclass</option>
 		</pluginOptions>
 	</configuration>
 </plugin>

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ compileTestKotlin {
 
 allOpen {
 	annotation('javax.persistence.Entity')
+	annotation('javax.persistence.Embeddable')
+	annotation('javax.persistence.MappedSuperclass')
 }
 
 repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,8 @@
 					</compilerPlugins>
 					<pluginOptions>
 						<option>all-open:annotation=javax.persistence.Entity</option>
+						<option>all-open:annotation=javax.persistence.Embeddable</option>
+						<option>all-open:annotation=javax.persistence.MappedSuperclass</option>
 					</pluginOptions>
 				</configuration>
 				<dependencies>


### PR DESCRIPTION
Even if this tutorial doesn't make use of `@Embeddable` or `@MappedSuperclass`, developers should employ it to learn how to work properly with JPA/Hibernate and Kotlin.