### PR TITLE
cUrl - use dependencies instead of style

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,7 +43,7 @@ You can use the Initializr HTTP API https://docs.spring.io/initializr/docs/curre
 [source]
 ----
 $ mkdir blog && cd blog
-$ curl https://start.spring.io/starter.zip -d language=kotlin -d style=web,mustache,jpa,h2,devtools -d packageName=com.example.blog -d name=Blog -o blog.zip
+$ curl https://start.spring.io/starter.zip -d language=kotlin -d dependencies=web,mustache,jpa,h2,devtools -d packageName=com.example.blog -d name=Blog -o blog.zip
 ----
 
 Add `-d type=gradle-project` if you want to use Gradle.


### PR DESCRIPTION
The response was 404 with the `style` parameter.

I was following this guide: https://spring.io/guides/tutorials/spring-boot-kotlin/ . Can it be updated too?
