### PR TITLE
Fix grammatical mistake in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -547,7 +547,7 @@ interface UserRepository : CrudRepository<User, Long> {
 }
 ----
 
-And we write JPA tests to check basic use cases works as expected.
+And we write JPA tests to check whether basic use cases work as expected.
 
 `src/test/kotlin/com/example/blog/RepositoriesTests.kt`
 [source,kotlin]


### PR DESCRIPTION
This PR proposes a fix for a small grammar mistake.