### PR TITLE
fix HttpControllersTests content type assertion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -856,7 +856,7 @@ class HttpControllersTests(@Autowired val mockMvc: MockMvc) {
 		every { articleRepository.findAllByOrderByAddedAtDesc() } returns listOf(spring5Article, spring43Article)
 		mockMvc.perform(get("/api/article/").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk)
-				.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("\$.[0].author.login").value(juergen.login))
 				.andExpect(jsonPath("\$.[0].slug").value(spring5Article.slug))
 				.andExpect(jsonPath("\$.[1].author.login").value(juergen.login))
@@ -870,7 +870,7 @@ class HttpControllersTests(@Autowired val mockMvc: MockMvc) {
 		every { userRepository.findAll() } returns listOf(juergen, smaldini)
 		mockMvc.perform(get("/api/user/").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk)
-				.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("\$.[0].login").value(juergen.login))
 				.andExpect(jsonPath("\$.[1].login").value(smaldini.login))
 	}


### PR DESCRIPTION
while following the tutorial I stumbled upon this wrong assertion in the tutorial.
This PR fixes the assertion to be the same as in the example code

