### PR TITLE
Add @TestInstance annotation and Lifecycle.PER_CLASS arg to IntegrationTests.kt

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -713,6 +713,7 @@ And we also update the integration tests accordingly.
 [source,kotlin]
 ----
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IntegrationTests(@Autowired val restTemplate: TestRestTemplate) {
 
 	@BeforeAll

--- a/src/test/kotlin/com/example/blog/IntegrationTests.kt
+++ b/src/test/kotlin/com/example/blog/IntegrationTests.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate

--- a/src/test/kotlin/com/example/blog/IntegrationTests.kt
+++ b/src/test/kotlin/com/example/blog/IntegrationTests.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.test.web.client.getForEntity
 import org.springframework.http.HttpStatus
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IntegrationTests(@Autowired val restTemplate: TestRestTemplate) {
 
 	@BeforeAll


### PR DESCRIPTION
Add @TestInstance annotation and Lifecycle.PER_CLASS arg to resolve exception in surefire report that setup() method in IntegrationTests.kt must be static